### PR TITLE
enable compiling agains legacy rabbitmq versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ On Debian-based OS:
 
 Note: Debian 12 (Bookworm) and below ship `hiredis` without SSL support. If you want to compile OpenSpy Core on Debian 12 and derived OS (like Ubuntu 22.04), you need to compile `hiredis` with `USE_SSL=1` yourself. As of Debian 13 (Trixie) the SSL version is already included.
 
+#### Compile against legacy versions of rabbitmq-c
+If you compile against a version of `rabbitmq-c` prior to `0.12`, you need to enable the compiler flag `USE_LEGACYRABBITMQ`:
+
+```
+cd <openspy-core-v2-master>/code
+mkdir build && cd build
+cmake -DUSE_LEGACYRABBITMQ=ON ..
+cmake --build .
+```
+
 ## Running
 If you refer to the "openspy-web-backend" project, this will have everything you need to get openspy running.
 From the perspective of this application, the requirements are redis, rabbitmq, and then the openspy-web-backend.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,27 @@ This is a full rewrite of the old openspy. Each service runs as a seperate proce
 ## Building
 A [docker file](Dockerfile) has been created to convey the required build and runtime environment. This has not been used for development, but can be helpful for testing and just getting the project running.
 
+### Compile using native libraries and cmake
+On Debian-based OS:
+
+1. install dependencies (as root):
+
+    ```
+    apt install libjansson-dev libhiredis-dev libuv1-dev libpugixml-dev librabbitmq-dev libssl-dev libcurl4-openssl-dev zlib1g-dev cmake build-essential
+    ```
+
+2. download and extract openspy
+3. compile
+
+    ```
+    cd <openspy-core-v2-master>/code
+    mkdir build && cd build
+    cmake ..
+    cmake --build .
+    ```
+
+Note: Debian 12 (Bookworm) and below ship `hiredis` without SSL support. If you want to compile OpenSpy Core on Debian 12 and derived OS (like Ubuntu 22.04), you need to compile `hiredis` with `USE_SSL=1` yourself. As of Debian 13 (Trixie) the SSL version is already included.
+
 ## Running
 If you refer to the "openspy-web-backend" project, this will have everything you need to get openspy running.
 From the perspective of this application, the requirements are redis, rabbitmq, and then the openspy-web-backend.

--- a/cmake/modules/Findhiredis.cmake
+++ b/cmake/modules/Findhiredis.cmake
@@ -1,0 +1,18 @@
+find_path(HIREDIS_INCLUDE_DIR NAMES hiredis/hiredis.h PATHS ${HIREDIS_ROOT_DIR} ${HIREDIS_ROOT_DIR}/include)
+
+find_library(HIREDIS_LIBRARIES NAMES hiredis PATHS ${HIREDIS_ROOT_DIR} ${HIREDIS_ROOT_DIR}/lib)
+
+if (HIREDIS_INCLUDE_DIR AND HIREDIS_LIBRARIES)
+  if (NOT TARGET hiredis::hiredis)
+    add_library(hiredis::hiredis UNKNOWN IMPORTED)
+    set_target_properties(hiredis::hiredis PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${HIREDIS_INCLUDE_DIR} IMPORTED_LOCATION ${HIREDIS_LIBRARIES})
+  endif ()
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(hiredis REQUIRED_VARS HIREDIS_INCLUDE_DIR HIREDIS_LIBRARIES)
+
+if(HIREDIS_FOUND)
+  message(STATUS "Found hiredis - (include: ${HIREDIS_INCLUDE_DIR}, library: ${HIREDIS_LIBRARIES})")
+  mark_as_advanced(HIREDIS_INCLUDE_DIR HIREDIS_LIBRARIES)
+endif()

--- a/cmake/modules/Findhiredis_ssl.cmake
+++ b/cmake/modules/Findhiredis_ssl.cmake
@@ -1,0 +1,18 @@
+find_path(HIREDIS_SSL_INCLUDE_DIR NAMES hiredis/hiredis_ssl.h PATHS ${HIREDIS_SSL_ROOT_DIR} ${HIREDIS_SSL_ROOT_DIR}/include)
+
+find_library(HIREDIS_SSL_LIBRARIES NAMES hiredis_ssl PATHS ${HIREDIS_SSL_ROOT_DIR} ${HIREDIS_SSL_ROOT_DIR}/lib)
+
+if (HIREDIS_SSL_INCLUDE_DIR AND HIREDIS_SSL_LIBRARIES)
+  if (NOT TARGET hiredis::hiredis_ssl)
+    add_library(hiredis::hiredis_ssl UNKNOWN IMPORTED)
+    set_target_properties(hiredis::hiredis_ssl PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${HIREDIS_SSL_INCLUDE_DIR} IMPORTED_LOCATION ${HIREDIS_SSL_LIBRARIES})
+  endif ()
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(hiredis_ssl REQUIRED_VARS HIREDIS_SSL_INCLUDE_DIR HIREDIS_SSL_LIBRARIES)
+
+if(HIREDIS_SSL_FOUND)
+  message(STATUS "Found hiredis_ssl - (include: ${HIREDIS_SSL_INCLUDE_DIR}, library: ${HIREDIS_SSL_LIBRARIES})")
+  mark_as_advanced(HIREDIS_SSL_INCLUDE_DIR HIREDIS_SSL_LIBRARIES)
+endif()

--- a/cmake/modules/Findjansson.cmake
+++ b/cmake/modules/Findjansson.cmake
@@ -1,0 +1,18 @@
+find_path(JANSSON_INCLUDE_DIR NAMES jansson.h PATHS ${JANSSON_ROOT_DIR})
+
+find_library(JANSSON_LIBRARIES NAMES jansson PATHS ${JANSSON_ROOT_DIR})
+
+if (JANSSON_INCLUDE_DIR AND JANSSON_LIBRARIES)
+  if (NOT TARGET jansson::jansson)
+    add_library(jansson::jansson UNKNOWN IMPORTED)
+    set_target_properties(jansson::jansson PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${JANSSON_INCLUDE_DIR} IMPORTED_LOCATION ${JANSSON_LIBRARIES})
+  endif ()
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(jansson REQUIRED_VARS JANSSON_INCLUDE_DIR JANSSON_LIBRARIES)
+
+if(JANSSON_FOUND)
+  message(STATUS "Found jansson - (include: ${JANSSON_INCLUDE_DIR}, library: ${JANSSON_LIBRARIES})")
+  mark_as_advanced(JANSSON_INCLUDE_DIR JANSSON_LIBRARIES)
+endif()

--- a/cmake/modules/Findlibuv.cmake
+++ b/cmake/modules/Findlibuv.cmake
@@ -1,0 +1,18 @@
+find_path(LIBUV_INCLUDE_DIR uv.h PATHS ${LIBUV_DIR} ${LIBUV_DIR}/include)
+
+find_library(LIBUV_LIBRARIES NAMES uv libuv PATHS ${LIBUV_DIR} ${LIBUV_DIR}/lib)
+
+if (LIBUV_INCLUDE_DIR AND LIBUV_LIBRARIES)
+  if (NOT TARGET libuv::uv)
+    add_library(libuv::uv UNKNOWN IMPORTED)
+    set_target_properties(libuv::uv PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBUV_INCLUDE_DIR} IMPORTED_LOCATION ${LIBUV_LIBRARIES})
+  endif ()
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(libuv REQUIRED_VARS LIBUV_LIBRARIES LIBUV_INCLUDE_DIR)
+
+if(LIBUV_FOUND)
+  message(STATUS "Found libuv - (include: ${LIBUV_INCLUDE_DIR}, library: ${LIBUV_LIBRARIES})")
+  mark_as_advanced(LIBUV_INCLUDE_DIR LIBUV_LIBRARIES)
+endif()

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -14,6 +14,11 @@ find_package(libuv REQUIRED)
 
 include_directories("core")
 
+#enable compiling agains rabbitmq-c <0.12
+option(USE_LEGACYRABBITMQ "Compiling against legacy versions of rabbitmq-c (<0.12)" OFF)
+if (USE_LEGACYRABBITMQ)
+  add_definitions(-DLEGACYRABBITMQ)
+endif()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/")

--- a/code/GP/tasks/tasks.cpp
+++ b/code/GP/tasks/tasks.cpp
@@ -1,5 +1,9 @@
 #include "tasks.h"
-#include <rabbitmq-c/tcp_socket.h>
+#ifdef LEGACYRABBITMQ
+	#include <amqp_tcp_socket.h>
+#else
+	#include <rabbitmq-c/tcp_socket.h>
+#endif
 
 #include <OS/tasks.h>
 

--- a/code/SharedTasks/src/OS/tasks.cpp
+++ b/code/SharedTasks/src/OS/tasks.cpp
@@ -1,9 +1,13 @@
 #include "tasks.h"
 #include <uv.h>
 
-
-#include <rabbitmq-c/amqp.h>
-#include <rabbitmq-c/tcp_socket.h>
+#ifdef LEGACYRABBITMQ
+	#include <amqp.h>
+	#include <amqp_tcp_socket.h>
+#else
+	#include <rabbitmq-c/amqp.h>
+	#include <rabbitmq-c/tcp_socket.h>
+#endif
 
 #include <OS/OpenSpy.h>
 

--- a/code/SharedTasks/src/OS/tasks.h
+++ b/code/SharedTasks/src/OS/tasks.h
@@ -3,7 +3,11 @@
 #include <string>
 #include <hiredis/hiredis.h>
 #include <hiredis/hiredis_ssl.h>
-#include <rabbitmq-c/amqp.h>
+#ifdef LEGACYRABBITMQ
+	#include <amqp.h>
+#else
+	#include <rabbitmq-c/amqp.h>
+#endif
 #include <uv.h>
 namespace OS {
 	class Address;

--- a/code/natneg/tasks/tasks.cpp
+++ b/code/natneg/tasks/tasks.cpp
@@ -1,5 +1,10 @@
-#include <rabbitmq-c/amqp.h>
-#include <rabbitmq-c/tcp_socket.h>
+#ifdef LEGACYRABBITMQ
+	#include <amqp.h>
+	#include <amqp_tcp_socket.h>
+#else
+	#include <rabbitmq-c/amqp.h>
+	#include <rabbitmq-c/tcp_socket.h>
+#endif
 
 #include <sstream>
 

--- a/code/natneg/tasks/tasks.h
+++ b/code/natneg/tasks/tasks.h
@@ -2,7 +2,11 @@
 #define _NN_TASKS_H
 #include <OS/OpenSpy.h>
 #include <string>
-#include <rabbitmq-c/amqp.h>
+#ifdef LEGACYRABBITMQ
+	#include <amqp.h>
+#else
+	#include <rabbitmq-c/amqp.h>
+#endif
 #include <server/structs.h>
 #include <uv.h>
 

--- a/code/peerchat/tasks/tasks.cpp
+++ b/code/peerchat/tasks/tasks.cpp
@@ -3,9 +3,13 @@
 #include <server/Server.h>
 #include <server/Peer.h>
 
-
-#include <rabbitmq-c/amqp.h>
-#include <rabbitmq-c/tcp_socket.h>
+#ifdef LEGACYRABBITMQ
+	#include <amqp.h>
+	#include <amqp_tcp_socket.h>
+#else
+	#include <rabbitmq-c/amqp.h>
+	#include <rabbitmq-c/tcp_socket.h>
+#endif
 
 namespace Peerchat {
 	const char *peerchat_channel_exchange = "peerchat.core";

--- a/code/qr/tasks/tasks.cpp
+++ b/code/qr/tasks/tasks.cpp
@@ -2,8 +2,13 @@
 
 #include "tasks.h"
 
-#include <rabbitmq-c/amqp.h>
-#include <rabbitmq-c/tcp_socket.h>
+#ifdef LEGACYRABBITMQ
+	#include <amqp.h>
+	#include <amqp_tcp_socket.h>
+#else
+	#include <rabbitmq-c/amqp.h>
+	#include <rabbitmq-c/tcp_socket.h>
+#endif
 
 
 namespace MM {

--- a/code/serverbrowsing/tasks/tasks.cpp
+++ b/code/serverbrowsing/tasks/tasks.cpp
@@ -1,8 +1,12 @@
 #include "tasks.h"
 
-#include <rabbitmq-c/amqp.h>
-#include <rabbitmq-c/tcp_socket.h>
-
+#ifdef LEGACYRABBITMQ
+	#include <amqp.h>
+	#include <amqp_tcp_socket.h>
+#else
+	#include <rabbitmq-c/amqp.h>
+	#include <rabbitmq-c/tcp_socket.h>
+#endif
 
 namespace MM {
 	const char *mm_channel_exchange = "openspy.master";

--- a/code/utmaster/tasks/tasks.cpp
+++ b/code/utmaster/tasks/tasks.cpp
@@ -1,5 +1,10 @@
-#include <rabbitmq-c/amqp.h>
-#include <rabbitmq-c/tcp_socket.h>
+#ifdef LEGACYRABBITMQ
+	#include <amqp.h>
+	#include <amqp_tcp_socket.h>
+#else
+	#include <rabbitmq-c/amqp.h>
+	#include <rabbitmq-c/tcp_socket.h>
+#endif
 #include "tasks.h"
 
 


### PR DESCRIPTION
Allows for compiling agains rabbitmq-c versions prior to their path changes (version <0.12). Needed for compiling agains system libs.
Use of the legacy version is hidden behind compiler flag `-DUSE_LEGACYRABBITMQ=ON`